### PR TITLE
compartment sets 2: reports

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -382,9 +382,10 @@ class SONATA_API SimulationConfig
      */
     struct Report {
         enum class Sections { invalid = -1, soma, axon, dend, apic, all };
-        enum class Type { invalid = -1, compartment, lfp, summation, synapse };
+        enum class Type { invalid = -1, compartment, lfp, summation, synapse, compartment_set };
         enum class Scaling { invalid = -1, none, area };
         enum class Compartments { invalid = -1, center, all };
+
 
         /// Node sets on which to report
         std::string cells;
@@ -398,6 +399,8 @@ class SONATA_API SimulationConfig
         /// For compartment type, select compartments to report.
         /// Default value: "center"(for sections: soma), "all"(for other sections)
         Compartments compartments;
+        /// Name of the compartment set (from compartment_set.json) used for generating the report.
+        std::string compartment_set;
         /// The simulation variable to access. The variables available are model dependent. For
         /// summation type, it supports multiple variables by comma separated strings. E.g. “ina”,
         /// "AdEx.V_M, v", "i_membrane, IClamp".

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -918,7 +918,8 @@ PYBIND11_MODULE(_libsonata, m) {
         .value("compartment", SimulationConfig::Report::Type::compartment)
         .value("lfp", SimulationConfig::Report::Type::lfp)
         .value("summation", SimulationConfig::Report::Type::summation)
-        .value("synapse", SimulationConfig::Report::Type::synapse);
+        .value("synapse", SimulationConfig::Report::Type::synapse)
+        .value("compartment_set", SimulationConfig::Report::Type::compartment_set);
 
     py::enum_<SimulationConfig::Report::Scaling>(report, "Scaling")
         .value("none", SimulationConfig::Report::Scaling::none)

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -446,7 +446,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(modifications["no_SK_E2"].section_configure, "%s.gSK_E2bar_SK_E2 = 0")
 
         self.assertEqual(self.config.list_report_names,
-                         { "axonal_comp_centers", "cell_imembrane", "compartment", "soma", "lfp" })
+                         { "axonal_comp_centers", "cell_imembrane", "compartment", "soma", "lfp", "compartment_set_v" })
 
         Report = SimulationConfig.Report
         self.assertEqual(self.config.report('soma').cells, 'Column')

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1148,18 +1148,29 @@ class SimulationConfig::Parser
 
             parseOptional(valueIt, "cells", report.cells, parseNodeSet());
             parseMandatory(valueIt, "type", debugStr, report.type);
-            if (report.type == Report::Type::compartment_set && valueIt.find("sections") != valueIt.end()) {
-                throw SonataError("Field 'sections' is not allowed for reports of type 'compartment_set'.");
+            if (report.type == Report::Type::compartment_set &&
+                valueIt.find("sections") != valueIt.end()) {
+                throw SonataError(
+                    "Field 'sections' is not allowed for reports of type 'compartment_set'.");
             }
-            parseOptional(valueIt, "sections", report.sections, {report.type == Report::Type::compartment_set ? Report::Sections::invalid : Report::Sections::soma});
-            if (report.type == Report::Type::compartment_set && valueIt.find("compartments") != valueIt.end()) {
-                throw SonataError("Field 'compartments' is not allowed for reports of type 'compartment_set'.");
+            parseOptional(valueIt,
+                          "sections",
+                          report.sections,
+                          {report.type == Report::Type::compartment_set ? Report::Sections::invalid
+                                                                        : Report::Sections::soma});
+            if (report.type == Report::Type::compartment_set &&
+                valueIt.find("compartments") != valueIt.end()) {
+                throw SonataError(
+                    "Field 'compartments' is not allowed for reports of type 'compartment_set'.");
             }
             parseOptional(valueIt,
                           "compartments",
                           report.compartments,
-                                                    {report.type == Report::Type::compartment_set ? Report::Compartments::invalid : (report.sections == Report::Sections::soma ? Report::Compartments::center
-                                                                     : Report::Compartments::all)});
+                          {report.type == Report::Type::compartment_set
+                               ? Report::Compartments::invalid
+                               : (report.sections == Report::Sections::soma
+                                      ? Report::Compartments::center
+                                      : Report::Compartments::all)});
             parseOptional(valueIt, "scaling", report.scaling, {Report::Scaling::area});
             parseMandatory(valueIt, "variable_name", debugStr, report.variableName);
             parseOptional(valueIt, "unit", report.unit, {"mV"});

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -83,7 +83,8 @@ NLOHMANN_JSON_SERIALIZE_ENUM(SimulationConfig::Report::Type,
                               {SimulationConfig::Report::Type::compartment, "compartment"},
                               {SimulationConfig::Report::Type::lfp, "lfp"},
                               {SimulationConfig::Report::Type::summation, "summation"},
-                              {SimulationConfig::Report::Type::synapse, "synapse"}})
+                              {SimulationConfig::Report::Type::synapse, "synapse"},
+                              {SimulationConfig::Report::Type::compartment_set, "compartment_set"}})
 NLOHMANN_JSON_SERIALIZE_ENUM(SimulationConfig::Report::Scaling,
                              {{SimulationConfig::Report::Scaling::invalid, nullptr},
                               {SimulationConfig::Report::Scaling::none, "none"},
@@ -1146,14 +1147,20 @@ class SimulationConfig::Parser
             const std::string debugStr = "report " + it.key();
 
             parseOptional(valueIt, "cells", report.cells, parseNodeSet());
-            parseOptional(valueIt, "sections", report.sections, {Report::Sections::soma});
             parseMandatory(valueIt, "type", debugStr, report.type);
-            parseOptional(valueIt, "scaling", report.scaling, {Report::Scaling::area});
+            if (report.type == Report::Type::compartment_set && valueIt.find("sections") != valueIt.end()) {
+                throw SonataError("Field 'sections' is not allowed for reports of type 'compartment_set'.");
+            }
+            parseOptional(valueIt, "sections", report.sections, {report.type == Report::Type::compartment_set ? Report::Sections::invalid : Report::Sections::soma});
+            if (report.type == Report::Type::compartment_set && valueIt.find("compartments") != valueIt.end()) {
+                throw SonataError("Field 'compartments' is not allowed for reports of type 'compartment_set'.");
+            }
             parseOptional(valueIt,
                           "compartments",
                           report.compartments,
-                          {report.sections == Report::Sections::soma ? Report::Compartments::center
-                                                                     : Report::Compartments::all});
+                                                    {report.type == Report::Type::compartment_set ? Report::Compartments::invalid : (report.sections == Report::Sections::soma ? Report::Compartments::center
+                                                                     : Report::Compartments::all)});
+            parseOptional(valueIt, "scaling", report.scaling, {Report::Scaling::area});
             parseMandatory(valueIt, "variable_name", debugStr, report.variableName);
             parseOptional(valueIt, "unit", report.unit, {"mV"});
             parseMandatory(valueIt, "dt", debugStr, report.dt);

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -308,6 +308,15 @@
              "start_time": 0,
              "end_time": 500,
              "enabled": true
+         },
+         "compartment_set_v": {
+            "type": "compartment_set",
+            "compartment_set": "cs0",
+            "variable_name": "v",
+            "unit": "mV",
+            "dt": 0.1,
+            "start_time": 0.0,
+            "end_time": 100.0
          }
     }
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -365,7 +365,8 @@ TEST_CASE("SimulationConfig") {
               "cell_imembrane",
               "compartment",
               "soma",
-              "lfp"
+              "lfp",
+              "compartment_set_v"
               });
 
         CHECK(config.getReport("soma").cells == "Column");


### PR DESCRIPTION
I was not aware that the parsing and validation of `simulation_config.json` was done by sonata too. This is also needed to implement fully compartment sets. 

The change is based on this proposal https://github.com/openbraininstitute/sonata-extension/pull/5

- new `Report::Type::compartment_set`: this disallows and (sets to `invalid` in the final product) the `sections` and `compartments` lines since they lose meaning if we use the `compartment_sets.json` file. 
- add a new compartment_sets report in `simulation_config.json` for testing.

