### PR TITLE
Replace "python setup.py sdist" with "python -m build --sdist"

### DIFF
--- a/ci/python_build_sdist.sh
+++ b/ci/python_build_sdist.sh
@@ -18,8 +18,8 @@ set +u  # ignore missing variables in activation script
 source "$BIN/activate"
 set -u
 
-"$BIN/pip" install -U setuptools pip twine
-"$BIN/python" setup.py sdist
+"$BIN/pip" install -U pip build
+"$BIN/python" -m build --sdist
 
 ls -al dist
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
     "cmake",
     "oldest-supported-numpy",
     "setuptools",
+    "setuptools_scm",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -99,10 +99,6 @@ install_requires = [
     "numpy>=1.17.3",
 ]
 
-setup_requires = [
-    "setuptools_scm",
-]
-
 with open('README.rst') as f:
     README = f.read()
 
@@ -118,7 +114,6 @@ setup(
     cmdclass={'build_ext': CMakeBuild,
               },
     zip_safe=False,
-    setup_requires=setup_requires,
     install_requires=install_requires,
     extras_require={
         'docs': ['sphinx-bluebrain-theme'],


### PR DESCRIPTION
`vcs_versioning` becomes the dependency of `setuptools_scm 10.0.3`. To solve the transitive dependency problem, we replace the legacy `python setup.py sdist` with the modern build `python -m build --sdist` which installs `vcs_versioning` from `setuptools_scm` via `pyproject.toml`

see CI failure in https://github.com/openbraininstitute/libsonata/actions/runs/23602189013/job/68734980261?pr=36