### PR TITLE
Don't use HDF5's default locking behavior when opening files read only

### DIFF
--- a/src/hdf5_reader.cpp
+++ b/src/hdf5_reader.cpp
@@ -1,9 +1,35 @@
 #include <bbp/sonata/hdf5_reader.h>
 
 #include "hdf5_reader.hpp"
+namespace {
+class HDF5Lock
+{
+    bool _use_file_locking;
+    bool _ignore_when_disabled;
+
+  public:
+    explicit HDF5Lock(bool use_file_locking, bool ignore_when_disabled)
+        : _use_file_locking(use_file_locking)
+        , _ignore_when_disabled(ignore_when_disabled) { }
+
+    void apply(const hid_t list) const {
+        herr_t err = H5Pset_file_locking(list, _use_file_locking, _ignore_when_disabled);
+        if (err < 0) {
+            HighFive::HDF5ErrMapper::ToException<HighFive::PropertyException>(
+                "Unable to set non-locking when opening file.");
+        }
+    }
+};
+}  // namespace
 
 namespace bbp {
 namespace sonata {
+HighFive::File openHDF5withoutLock(const std::string& path) {
+    HighFive::FileAccessProps fapl = HighFive::FileAccessProps::Default();
+    fapl.add(HDF5Lock(false, true));
+
+    return HighFive::File(path, /*openFlags*/ HighFive::File::AccessMode::ReadOnly, fapl);
+}
 
 
 Hdf5Reader::Hdf5Reader()

--- a/src/hdf5_reader.hpp
+++ b/src/hdf5_reader.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "population.hpp"
-#include "read_bulk.hpp"
 #include "read_canonical_selection.hpp"
 
 namespace bbp {
 namespace sonata {
+HighFive::File openHDF5withoutLock(const std::string& path);
 
 namespace detail {
 template <class Range>
@@ -20,7 +19,6 @@ HighFive::HyperSlab _makeHyperslab(const std::vector<Range>& ranges) {
     return slab;
 }
 }  // namespace detail
-
 
 template <class T>
 class Hdf5PluginRead1DDefault: virtual public Hdf5PluginRead1DInterface<T>
@@ -42,7 +40,6 @@ class Hdf5PluginRead2DDefault: virtual public Hdf5PluginRead2DInterface<T>
         return detail::readCanonicalSelection<T>(dset, xsel, ysel);
     }
 };
-
 template <class T, class U>
 class Hdf5PluginDefault;
 
@@ -54,7 +51,7 @@ class Hdf5PluginDefault<std::tuple<Ts...>, std::tuple<Us...>>
 {
   public:
     HighFive::File openFile(const std::string& path) const override {
-        return HighFive::File(path);
+        return openHDF5withoutLock(path);
     }
 };
 

--- a/src/population.hpp
+++ b/src/population.hpp
@@ -20,6 +20,7 @@
 
 #include <fmt/format.h>
 
+#include "hdf5_reader.hpp"
 #include "read_bulk.hpp"
 #include <highfive/H5File.hpp>
 
@@ -179,7 +180,7 @@ struct PopulationStorage<Population>::Impl {
          const Hdf5Reader& hdf5_reader)
         : h5FilePath(_h5FilePath)
         , csvFilePath(_csvFilePath)
-        , h5File(h5FilePath)
+        , h5File(bbp::sonata::openHDF5withoutLock(h5FilePath))
         , h5Root(h5File.getGroup(fmt::format("/{}s", Population::ELEMENT)))
         , hdf5_reader(hdf5_reader) {
         if (!csvFilePath.empty()) {

--- a/src/report_reader.cpp
+++ b/src/report_reader.cpp
@@ -1,3 +1,4 @@
+#include "hdf5_reader.hpp"
 #include <bbp/sonata/report_reader.h>
 #include <fmt/format.h>
 
@@ -101,7 +102,7 @@ SpikeReader::SpikeReader(std::string filename)
     : filename_(std::move(filename)) { }
 
 std::vector<std::string> SpikeReader::getPopulationNames() const {
-    HighFive::File file(filename_, HighFive::File::ReadOnly);
+    HighFive::File file = openHDF5withoutLock(filename_);
     return file.getGroup("/spikes").listObjectNames();
 }
 
@@ -202,7 +203,8 @@ std::string SpikeReader::Population::getTimeUnits() const {
 
 SpikeReader::Population::Population(const std::string& filename,
                                     const std::string& populationName) {
-    HighFive::File file(filename, HighFive::File::ReadOnly);
+    HighFive::File file = openHDF5withoutLock(filename);
+
     const auto pop_path = std::string("/spikes/") + populationName;
     const auto pop = file.getGroup(pop_path);
     auto& node_ids = spike_times_.node_ids;
@@ -248,7 +250,7 @@ void SpikeReader::Population::filterTimestamp(Spikes& spikes, double tstart, dou
 
 template <typename T>
 ReportReader<T>::ReportReader(const std::string& filename)
-    : file_(filename, HighFive::File::ReadOnly) { }
+    : file_(openHDF5withoutLock(filename)) { }
 
 template <typename T>
 std::vector<std::string> ReportReader<T>::getPopulationNames() const {


### PR DESCRIPTION
* HDF5 uses file locks to implement a `Single Writer, Multiple Reader` model
* We expect the SONATA HDF5 files to always be finished reading, so we
  don't benefit from this, and on some files systems, there are a finite
  amount of locks (plus it's a pessimizing default)
* we don't want to rely on `HDF5_USE_FILE_LOCKING` to be set
* see more info: https://support.hdfgroup.org/documentation/hdf5/latest/_file_lock.html
* Note: this requires that any other files opened with the HDF5 library
  be opened with the same flags.  Thus, if `h5py` is used to open the file
  concurrently with `libsonata`, there may be failures if the locking
  flags aren't set the same we are using `use_file_locking=True` and
  `ignore_when_disabled=True`