### PR TITLE
Follow SONATA circuit_config standard by having `target_simulator`

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -30,6 +30,8 @@ namespace sonata {
 
 using variantValueType = nonstd::variant<bool, std::string, int, double>;
 
+enum class SimulatorType { invalid = -1, NEURON, CORENEURON, LEARNINGENGINE, BRIAN2 };
+
 struct CommonPopulationProperties {
     /**
      * Population type
@@ -176,6 +178,11 @@ class SONATA_API CircuitConfig
     const std::string& getCompartmentSetsPath() const;
 
     /**
+     * Returns target simulator
+     */
+    const SimulatorType& getTargetSimulator() const;
+
+    /**
      *  Returns a set with all available population names across all the node networks.
      */
     std::set<std::string> listNodePopulations() const;
@@ -256,6 +263,9 @@ class SONATA_API CircuitConfig
 
     // Edge populations that override default components variables
     std::unordered_map<std::string, EdgePopulationProperties> _edgePopulationProperties;
+
+    // Name of simulator
+    SimulatorType _targetSimulator;
 };
 
 /**
@@ -794,8 +804,6 @@ class SONATA_API SimulationConfig
         nonstd::optional<double> neuromodulationStrength{nonstd::nullopt};
     };
 
-    enum class SimulatorType { invalid = -1, NEURON, CORENEURON, LEARNINGENGINE };
-
     /**
      * Parses a SONATA JSON simulation configuration file.
      *
@@ -881,7 +889,7 @@ class SONATA_API SimulationConfig
      * Returns the name of simulator, default = NEURON
      * \throws SonataError if the given value is neither NEURON nor CORENEURON
      */
-    const SimulationConfig::SimulatorType& getTargetSimulator() const;
+    const SimulatorType& getTargetSimulator() const;
 
     /**
      * Returns the path of node sets file overriding node_sets_file provided in _network,

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -729,6 +729,12 @@ PYBIND11_MODULE(_libsonata, m) {
                       &EdgePopulationProperties::spineMorphologiesDir,
                       DOC_EDGE_POPULATION_PROPERTIES(spineMorphologiesDir));
 
+    py::enum_<SimulatorType>(m, "SimulatorType", "SimulatorType Enum", py::module_local())
+        .value("NEURON", SimulatorType::NEURON)
+        .value("CORENEURON", SimulatorType::CORENEURON)
+        .value("LearningEngine", SimulatorType::LEARNINGENGINE)
+        .value("Brian2", SimulatorType::BRIAN2);
+
     py::enum_<CircuitConfig::ConfigStatus>(m, "CircuitConfigStatus")
         .value("invalid", CircuitConfig::ConfigStatus::invalid)
         .value("complete", CircuitConfig::ConfigStatus::complete)
@@ -743,6 +749,8 @@ PYBIND11_MODULE(_libsonata, m) {
         .def_property_readonly("config_status", &CircuitConfig::getCircuitConfigStatus, "ibid")
         .def_property_readonly("node_sets_path", &CircuitConfig::getNodeSetsPath)
         .def_property_readonly("node_populations", &CircuitConfig::listNodePopulations)
+        .def_property_readonly("target_simulator", &CircuitConfig::getTargetSimulator)
+
         .def("node_population",
              [](const CircuitConfig& config, const std::string& name) {
                  return config.getNodePopulation(name);
@@ -1390,11 +1398,6 @@ PYBIND11_MODULE(_libsonata, m) {
         .def_property_readonly("beta_features",
                                &SimulationConfig::getBetaFeatures,
                                DOC_SIMULATIONCONFIG(getBetaFeatures));
-
-    py::enum_<SimulationConfig::SimulatorType>(simConf, "SimulatorType", "SimulatorType Enum")
-        .value("NEURON", SimulationConfig::SimulatorType::NEURON)
-        .value("CORENEURON", SimulationConfig::SimulatorType::CORENEURON)
-        .value("LearningEngine", SimulationConfig::SimulatorType::LEARNINGENGINE);
 
     bindPopulationClass<EdgePopulation>(
         m, "EdgePopulation", "Collection of edges with attributes and connectivity index")

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -133,6 +133,8 @@ Throws:
 
 static const char *__doc_bbp_sonata_CircuitConfig_getNodeSetsPath = R"doc(Returns the path to the node sets file.)doc";
 
+static const char *__doc_bbp_sonata_CircuitConfig_getTargetSimulator = R"doc(Returns target simulator)doc";
+
 static const char *__doc_bbp_sonata_CircuitConfig_listEdgePopulations =
 R"doc(Returns a set with all available population names across all the edge
 networks.)doc";
@@ -146,6 +148,8 @@ static const char *__doc_bbp_sonata_CircuitConfig_nodePopulationProperties = R"d
 static const char *__doc_bbp_sonata_CircuitConfig_nodeSetsFile = R"doc()doc";
 
 static const char *__doc_bbp_sonata_CircuitConfig_status = R"doc()doc";
+
+static const char *__doc_bbp_sonata_CircuitConfig_targetSimulator = R"doc()doc";
 
 static const char *__doc_bbp_sonata_CommonPopulationProperties = R"doc()doc";
 
@@ -1451,16 +1455,6 @@ Throws:
     SonataError on: - Ill-formed JSON - Missing mandatory entries (in
     any depth))doc";
 
-static const char *__doc_bbp_sonata_SimulationConfig_SimulatorType = R"doc()doc";
-
-static const char *__doc_bbp_sonata_SimulationConfig_SimulatorType_CORENEURON = R"doc()doc";
-
-static const char *__doc_bbp_sonata_SimulationConfig_SimulatorType_LEARNINGENGINE = R"doc()doc";
-
-static const char *__doc_bbp_sonata_SimulationConfig_SimulatorType_NEURON = R"doc()doc";
-
-static const char *__doc_bbp_sonata_SimulationConfig_SimulatorType_invalid = R"doc()doc";
-
 static const char *__doc_bbp_sonata_SimulationConfig_basePath = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_betaFeatures = R"doc()doc";
@@ -1558,6 +1552,18 @@ static const char *__doc_bbp_sonata_SimulationConfig_reports = R"doc()doc";
 static const char *__doc_bbp_sonata_SimulationConfig_run = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_targetSimulator = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulatorType = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulatorType_BRIAN2 = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulatorType_CORENEURON = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulatorType_LEARNINGENGINE = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulatorType_NEURON = R"doc()doc";
+
+static const char *__doc_bbp_sonata_SimulatorType_invalid = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SonataError = R"doc()doc";
 

--- a/python/libsonata/__init__.py
+++ b/python/libsonata/__init__.py
@@ -5,6 +5,7 @@
 
 from libsonata._libsonata import (
     CircuitConfig,
+    SimulatorType,
     CircuitConfigStatus,
     SimulationConfig,
     EdgePopulation,
@@ -29,6 +30,8 @@ from libsonata._libsonata import (
     Hdf5Reader,
 )
 
+# maintain backwarks compatibility
+setattr(SimulationConfig, 'SimulatorType', SimulatorType)
 
 __all__ = [
     "CircuitConfig",

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -2,8 +2,13 @@ import json
 import os
 import unittest
 
-from libsonata import (CircuitConfig, CircuitConfigStatus, SimulationConfig, SonataError,
-                       )
+from libsonata import (
+    CircuitConfig,
+    CircuitConfigStatus,
+    SimulationConfig,
+    SonataError,
+    SimulatorType,
+)
 
 
 PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -29,6 +34,14 @@ class TestCircuitConfig(unittest.TestCase):
         self.assertEqual(self.config.edge_population('edges-AB').name, 'edges-AB')
 
         self.assertEqual(self.config.config_status, CircuitConfigStatus.complete)
+
+        self.assertEqual(self.config.target_simulator, SimulatorType.CORENEURON)
+
+        #default to NEURON when missing `target_simulator`
+        contents = json.loads(self.config.expanded_json)
+        del contents["target_simulator"]
+        config = CircuitConfig(json.dumps(contents), './')
+        self.assertEqual(config.target_simulator, SimulatorType.NEURON)
 
     def test_expanded_json(self):
         config = json.loads(self.config.expanded_json)
@@ -1036,7 +1049,7 @@ class TestSimulationConfig(unittest.TestCase):
                 ))
 
     def test_target_simulator_types(self):
-        contents = {
+        contents: dict = {
             "run": {
                 "random_seed": 12345,
                 "dt": 0.05,
@@ -1044,7 +1057,11 @@ class TestSimulationConfig(unittest.TestCase):
                 }
             }
 
-        # default to NEURON
+        # default to NEURON, since no `network` exists to check
+        res = SimulationConfig(json.dumps(contents), "./")
+        self.assertEqual(res.target_simulator, SimulationConfig.SimulatorType.NEURON)
+
+        # default to NEURON, since no `network` exists to check
         res = SimulationConfig(json.dumps(contents), "./")
         self.assertEqual(res.target_simulator, SimulationConfig.SimulatorType.NEURON)
 
@@ -1063,6 +1080,12 @@ class TestSimulationConfig(unittest.TestCase):
         contents["target_simulator"] = "fake-simulator"
         with self.assertRaises(SonataError):
             self.assertRaises(SimulationConfig(json.dumps(contents), "./"))
+
+        # when it doesn't exist in the simulation_config, fallback to circuit_config
+        contents["network"] = "config/circuit_config.json"
+        del contents["target_simulator"]
+        res = SimulationConfig(json.dumps(contents), PATH)
+        self.assertEqual(res.target_simulator, SimulationConfig.SimulatorType.CORENEURON)
 
     def test_seclamp_failures(self):
         # SEClamp with delay

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -125,11 +125,12 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
      {SimulationConfig::InputBase::InputType::voltage_clamp, "voltage_clamp"},
      {SimulationConfig::InputBase::InputType::conductance, "conductance"}})
 
-NLOHMANN_JSON_SERIALIZE_ENUM(SimulationConfig::SimulatorType,
-                             {{SimulationConfig::SimulatorType::invalid, nullptr},
-                              {SimulationConfig::SimulatorType::NEURON, "NEURON"},
-                              {SimulationConfig::SimulatorType::CORENEURON, "CORENEURON"},
-                              {SimulationConfig::SimulatorType::LEARNINGENGINE, "LearningEngine"}})
+NLOHMANN_JSON_SERIALIZE_ENUM(SimulatorType,
+                             {{SimulatorType::invalid, nullptr},
+                              {SimulatorType::NEURON, "NEURON"},
+                              {SimulatorType::CORENEURON, "CORENEURON"},
+                              {SimulatorType::LEARNINGENGINE, "LearningEngine"},
+                              {SimulatorType::BRIAN2, "Brian2"}})
 
 NLOHMANN_JSON_SERIALIZE_ENUM(
     SimulationConfig::ModificationBase::ModificationType,
@@ -981,6 +982,12 @@ class CircuitConfig::Parser
         }
     }
 
+    SimulatorType parseTargetSimulator() const {
+        SimulatorType val = SimulatorType::NEURON;
+        parseOptional(_json, "target_simulator", val, {SimulatorType::NEURON});
+        return val;
+    }
+
     template <typename JSON>
     std::tuple<std::string, std::string> parseSubNetworks(const std::string& prefix,
                                                           const JSON& value) const {
@@ -1096,6 +1103,7 @@ CircuitConfig::CircuitConfig(const std::string& contents, const std::string& bas
 
     _nodePopulationProperties = parser.parseNodePopulations(_status);
     _edgePopulationProperties = parser.parseEdgePopulations(_status);
+    _targetSimulator = parser.parseTargetSimulator();
 
     Components defaultComponents = parser.parseDefaultComponents();
 
@@ -1173,6 +1181,10 @@ EdgePopulationProperties CircuitConfig::getEdgePopulationProperties(const std::s
 
 const std::string& CircuitConfig::getExpandedJSON() const {
     return _expandedJSON;
+}
+
+const SimulatorType& CircuitConfig::getTargetSimulator() const {
+    return _targetSimulator;
 }
 
 class SimulationConfig::Parser
@@ -1344,9 +1356,21 @@ class SimulationConfig::Parser
         return toAbsolute(_basePath, val);
     }
 
-    SimulationConfig::SimulatorType parseTargetSimulator() const {
-        SimulationConfig::SimulatorType val = SimulationConfig::SimulatorType::NEURON;
-        parseOptional(_json, "target_simulator", val, {SimulationConfig::SimulatorType::NEURON});
+    SimulatorType parseTargetSimulator() const {
+        SimulatorType val = SimulatorType::NEURON;
+        if (_json.contains("target_simulator")) {
+            parseOptional(_json, "target_simulator", val, {SimulatorType::NEURON});
+            return val;
+        } else {
+            try {
+                const auto circuitFile = parseNetwork();
+                const auto conf = CircuitConfig::fromFile(circuitFile);
+                return conf.getTargetSimulator();
+            } catch (...) {
+                // Don't throw CircuitConfig exceptions in SimulationConfig and return empty string
+                return val;
+            }
+        }
         return val;
     }
 
@@ -1625,7 +1649,7 @@ const std::vector<SimulationConfig::ConnectionOverride>& SimulationConfig::getCo
     return _connection_overrides;
 }
 
-const SimulationConfig::SimulatorType& SimulationConfig::getTargetSimulator() const {
+const SimulatorType& SimulationConfig::getTargetSimulator() const {
     return _targetSimulator;
 }
 

--- a/tests/data/config/circuit_config.json
+++ b/tests/data/config/circuit_config.json
@@ -1,5 +1,5 @@
 {
-  "target_simulator": "NEURON",
+  "target_simulator": "CORENEURON",
   "manifest": {
     "$BASE_DIR": "./",
     "$COMPONENT_DIR": "$BASE_DIR",

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -415,7 +415,7 @@ TEST_CASE("SimulationConfig") {
 
         const auto network = fs::absolute(basePath / fs::path("circuit_config.json"));
         CHECK(config.getNetwork() == network.lexically_normal());
-        CHECK(config.getTargetSimulator() == SimulationConfig::SimulatorType::CORENEURON);
+        CHECK(config.getTargetSimulator() == SimulatorType::CORENEURON);
         const auto circuit_conf = CircuitConfig::fromFile(config.getNetwork());
         CHECK(config.getNodeSetsFile() == circuit_conf.getNodeSetsPath());
         CHECK(config.getNodeSet() == "Column");
@@ -730,7 +730,7 @@ TEST_CASE("SimulationConfig") {
         const auto config = SimulationConfig(contents, basePath);
         const auto network = fs::absolute(basePath / "circuit" / fs::path("circuit_config.json"));
         CHECK(config.getNetwork() == network.lexically_normal());
-        CHECK(config.getTargetSimulator() == SimulationConfig::SimulatorType::NEURON);  // default
+        CHECK(config.getTargetSimulator() == SimulatorType::NEURON);  // default
         CHECK(config.getNodeSetsFile() == "");  // network file is not readable so default empty
         CHECK(config.getNodeSet() == nonstd::nullopt);  // default
         CHECK(config.getRun().stimulusSeed == 0);


### PR DESCRIPTION
* Previously, only the simulation config had it; however, the official specification has it in the circuit_config; see https://github.com/openbraininstitute/sonata-extension/pull/31
* Note this is an API change for C++; maintained compatibility in python
* also add BRIAN2 as a `SimulatorType`