### PR TITLE
Preserve input names order from config file

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -939,7 +939,7 @@ class SONATA_API SimulationConfig
     std::string _network;
     // List of inputs
     InputMap _inputs;
-    // Input names in config-file order (no duplicates)
+    // Input names in config-file order
     std::vector<std::string> _inputNames;
     // List of connections
     std::vector<ConnectionOverride> _connection_overrides;

--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -860,9 +860,9 @@ class SONATA_API SimulationConfig
     const Report& getReport(const std::string& name) const;
 
     /**
-     * Returns the names of the inputs
+     * Returns the names of the inputs in the order they appear in the config
      */
-    std::set<std::string> listInputNames() const;
+    const std::vector<std::string>& listInputNames() const noexcept;
 
     /**
      * Returns the given input parameters.
@@ -939,6 +939,8 @@ class SONATA_API SimulationConfig
     std::string _network;
     // List of inputs
     InputMap _inputs;
+    // Input names in config-file order (no duplicates)
+    std::vector<std::string> _inputNames;
     // List of connections
     std::vector<ConnectionOverride> _connection_overrides;
     // Name of simulator

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -1537,9 +1537,11 @@ R"doc(Returns the name of simulator, default = NEURON
 Throws:
     SonataError if the given value is neither NEURON nor CORENEURON)doc";
 
+static const char *__doc_bbp_sonata_SimulationConfig_inputNames = R"doc()doc";
+
 static const char *__doc_bbp_sonata_SimulationConfig_inputs = R"doc()doc";
 
-static const char *__doc_bbp_sonata_SimulationConfig_listInputNames = R"doc(Returns the names of the inputs)doc";
+static const char *__doc_bbp_sonata_SimulationConfig_listInputNames = R"doc(Returns the names of the inputs in the order they appear in the config)doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_listReportNames = R"doc(Returns the names of the reports)doc";
 

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -492,26 +492,26 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.node_set, 'Column')
 
         self.assertEqual(self.config.list_input_names,
-                         {"ex_abs_shotnoise",
-                          "ex_hyperpolarizing",
-                          "ex_linear",
+                         ["ex_linear",
                           "ex_linear_compartment_set",
-                          "ex_noise_mean",
-                          "ex_noise_meanpercent",
-                          "ex_OU",
-                          "ex_pulse",
                           "ex_rel_linear",
-                          "ex_rel_OU",
-                          "ex_rel_shotnoise",
-                          "ex_replay",
-                          "ex_seclamp",
-                          "ex_shotnoise",
+                          "ex_pulse",
                           "ex_sinusoidal",
                           "ex_sinusoidal_default_dt",
                           "ex_subthreshold",
+                          "ex_shotnoise",
+                          "ex_hyperpolarizing",
+                          "ex_seclamp",
+                          "ex_noise_meanpercent",
+                          "ex_noise_mean",
+                          "ex_rel_shotnoise",
+                          "ex_abs_shotnoise",
+                          "ex_replay",
+                          "ex_OU",
+                          "ex_rel_OU",
                           "ex_efields",
                           "ex_efields_noramp"
-                          })
+                          ])
 
         self.assertEqual(self.config.input('ex_linear').input_type.name, 'current_clamp')
         self.assertEqual(self.config.input('ex_linear').module.name, 'linear')

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -11,7 +11,9 @@
 
 #include <bbp/sonata/config.h>
 
+#include <algorithm>
 #include <bbp/sonata/optional.hpp>
+#include <iterator>
 #include <regex>
 #include <set>
 #include <string>
@@ -1542,16 +1544,16 @@ class SimulationConfig::Parser
     }
 
     std::vector<std::string> parseInputNames() const {
-        std::vector<std::string> result;
         const auto it = _orderedJson.find("inputs");
         if (it == _orderedJson.end()) {
-            return result;
+            return {};
         }
-        std::unordered_set<std::string> seen;
-        for (auto kv = it->begin(); kv != it->end(); ++kv) {
-            if (seen.insert(kv.key()).second) {
-                result.push_back(kv.key());
-            }
+        // No need to check for duplicate keys here: parseJSONRejectDuplicateKeys()
+        // already throws on duplicates during construction, before this is called.
+        std::vector<std::string> result;
+        result.reserve(it->size());
+        for (const auto& kv : it->items()) {
+            result.push_back(kv.key());
         }
         return result;
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1179,7 +1179,8 @@ class SimulationConfig::Parser
 {
   public:
     Parser(const std::string& content, const std::string& basePath)
-        : _basePath(fs::absolute(fs::path(basePath)).lexically_normal()) {
+        : _basePath(fs::absolute(fs::path(basePath)).lexically_normal())
+        , _orderedJson(nlohmann::ordered_json::parse(content)) {
         // Parse manifest section and expand JSON string
         const auto rawJson = parseJSONRejectDuplicateKeys(content);
         const auto vars = replaceVariables(readVariables(rawJson));
@@ -1540,8 +1541,24 @@ class SimulationConfig::Parser
         return _json.dump();
     }
 
+    std::vector<std::string> parseInputNames() const {
+        std::vector<std::string> result;
+        const auto it = _orderedJson.find("inputs");
+        if (it == _orderedJson.end()) {
+            return result;
+        }
+        std::unordered_set<std::string> seen;
+        for (auto kv = it->begin(); kv != it->end(); ++kv) {
+            if (seen.insert(kv.key()).second) {
+                result.push_back(kv.key());
+            }
+        }
+        return result;
+    }
+
   private:
     const fs::path _basePath;
+    const nlohmann::ordered_json _orderedJson;
     nlohmann::json _json;
 };
 
@@ -1555,6 +1572,7 @@ SimulationConfig::SimulationConfig(const std::string& content, const std::string
     _reports = parser.parseReports(_output);
     _network = parser.parseNetwork();
     _inputs = parser.parseInputs(_run.dt);
+    _inputNames = parser.parseInputNames();
     _connection_overrides = parser.parseConnectionOverrides();
     _targetSimulator = parser.parseTargetSimulator();
     _nodeSetsFile = parser.parseNodeSetsFile();
@@ -1607,8 +1625,8 @@ const SimulationConfig::Report& SimulationConfig::getReport(const std::string& n
     return it->second;
 }
 
-std::set<std::string> SimulationConfig::listInputNames() const {
-    return getMapKeys(_inputs);
+const std::vector<std::string>& SimulationConfig::listInputNames() const noexcept {
+    return _inputNames;
 }
 
 const SimulationConfig::Input& SimulationConfig::getInput(const std::string& name) const {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -11,9 +11,7 @@
 
 #include <bbp/sonata/config.h>
 
-#include <algorithm>
 #include <bbp/sonata/optional.hpp>
-#include <iterator>
 #include <regex>
 #include <set>
 #include <string>

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -649,25 +649,25 @@ TEST_CASE("SimulationConfig") {
             CHECK(fields[0].frequency == 0.);
             CHECK(fields[0].phase == 0.);
         }
-        CHECK(config.listInputNames() == std::set<std::string>{"ex_abs_shotnoise",
-                                                               "ex_hyperpolarizing",
-                                                               "ex_linear",
-                                                               "ex_linear_compartment_set",
-                                                               "ex_noise_mean",
-                                                               "ex_noise_meanpercent",
-                                                               "ex_OU",
-                                                               "ex_pulse",
-                                                               "ex_rel_linear",
-                                                               "ex_rel_OU",
-                                                               "ex_rel_shotnoise",
-                                                               "ex_replay",
-                                                               "ex_seclamp",
-                                                               "ex_shotnoise",
-                                                               "ex_sinusoidal",
-                                                               "ex_sinusoidal_default_dt",
-                                                               "ex_subthreshold",
-                                                               "ex_efields",
-                                                               "ex_efields_noramp"});
+        CHECK(config.listInputNames() == std::vector<std::string>{"ex_linear",
+                                                                  "ex_linear_compartment_set",
+                                                                  "ex_rel_linear",
+                                                                  "ex_pulse",
+                                                                  "ex_sinusoidal",
+                                                                  "ex_sinusoidal_default_dt",
+                                                                  "ex_subthreshold",
+                                                                  "ex_shotnoise",
+                                                                  "ex_hyperpolarizing",
+                                                                  "ex_seclamp",
+                                                                  "ex_noise_meanpercent",
+                                                                  "ex_noise_mean",
+                                                                  "ex_rel_shotnoise",
+                                                                  "ex_abs_shotnoise",
+                                                                  "ex_replay",
+                                                                  "ex_OU",
+                                                                  "ex_rel_OU",
+                                                                  "ex_efields",
+                                                                  "ex_efields_noramp"});
 
         auto overrides = config.getConnectionOverrides();
         CHECK(overrides[0].name == "ConL3Exc-Uni");
@@ -1960,7 +1960,7 @@ TEST_CASE("SimulationConfig") {
               "ABC": 1,
                "mechanisms": {
                   "ABC": {"A":1},
-                  "ABC": {"A":1},
+                  "ABC": {"A":1}
                 }
               }
           })";


### PR DESCRIPTION
## Context

InputNames does not preserve order. If we add this here, we can simplify the logic in neurodamus

## Scope

- listInputNames() now returns a std::vector<std::string> preserving the insertion order from the JSON config file, instead of a std::set<std::string> which sorted alphabetically.
- The order of stimulus injection matters for simulation results, so the original file order must be preserved. A second parse using nlohmann::ordered_json extracts the input keys in file order.

## Tests

- The test config is reordered to put ex_shotnoise first, making any alphabetical-sorting regression immediately visible.