### PR TITLE
unspecified `target_simulator`

### DIFF
--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, macos-15-intel]
+        os: [ubuntu-22.04, macos-14, macos-15-intel]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-14, macos-15-intel]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, macos-15-intel]
 
     steps:
       - uses: actions/checkout@v4

--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -30,7 +30,7 @@ namespace sonata {
 
 using variantValueType = nonstd::variant<bool, std::string, int, double>;
 
-enum class SimulatorType { invalid = -1, NEURON, CORENEURON, LEARNINGENGINE, BRIAN2 };
+enum class SimulatorType { invalid = -1, NEURON, CORENEURON, LEARNINGENGINE, BRIAN2, UNSPECIFIED };
 
 struct CommonPopulationProperties {
     /**

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -736,7 +736,8 @@ PYBIND11_MODULE(_libsonata, m) {
         .value("NEURON", SimulatorType::NEURON)
         .value("CORENEURON", SimulatorType::CORENEURON)
         .value("LearningEngine", SimulatorType::LEARNINGENGINE)
-        .value("Brian2", SimulatorType::BRIAN2);
+        .value("Brian2", SimulatorType::BRIAN2)
+        .value("UNSPECIFIED", SimulatorType::UNSPECIFIED);
 
     py::enum_<CircuitConfig::ConfigStatus>(m, "CircuitConfigStatus")
         .value("invalid", CircuitConfig::ConfigStatus::invalid)

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -1577,6 +1577,8 @@ static const char *__doc_bbp_sonata_SimulatorType_LEARNINGENGINE = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SimulatorType_NEURON = R"doc()doc";
 
+static const char *__doc_bbp_sonata_SimulatorType_UNSPECIFIED = R"doc()doc";
+
 static const char *__doc_bbp_sonata_SimulatorType_invalid = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SonataError = R"doc()doc";

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -1070,11 +1070,7 @@ class TestSimulationConfig(unittest.TestCase):
 
         # default to NEURON, since no `network` exists to check
         res = SimulationConfig(json.dumps(contents), "./")
-        self.assertEqual(res.target_simulator, SimulationConfig.SimulatorType.NEURON)
-
-        # default to NEURON, since no `network` exists to check
-        res = SimulationConfig(json.dumps(contents), "./")
-        self.assertEqual(res.target_simulator, SimulationConfig.SimulatorType.NEURON)
+        self.assertEqual(res.target_simulator, SimulationConfig.SimulatorType.UNSPECIFIED)
 
         contents["target_simulator"] = "NEURON"
         res = SimulationConfig(json.dumps(contents), "./")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -127,11 +127,14 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
      {SimulationConfig::InputBase::InputType::conductance, "conductance"}})
 
 NLOHMANN_JSON_SERIALIZE_ENUM(SimulatorType,
-                             {{SimulatorType::invalid, nullptr},
-                              {SimulatorType::NEURON, "NEURON"},
-                              {SimulatorType::CORENEURON, "CORENEURON"},
-                              {SimulatorType::LEARNINGENGINE, "LearningEngine"},
-                              {SimulatorType::BRIAN2, "Brian2"}})
+                             {
+                                 {SimulatorType::invalid, nullptr},
+                                 {SimulatorType::NEURON, "NEURON"},
+                                 {SimulatorType::CORENEURON, "CORENEURON"},
+                                 {SimulatorType::LEARNINGENGINE, "LearningEngine"},
+                                 {SimulatorType::BRIAN2, "Brian2"},
+                                 {SimulatorType::UNSPECIFIED, "unspecified"},
+                             })
 
 NLOHMANN_JSON_SERIALIZE_ENUM(
     SimulationConfig::ModificationBase::ModificationType,
@@ -1384,8 +1387,7 @@ class SimulationConfig::Parser
                 const auto conf = CircuitConfig::fromFile(circuitFile);
                 return conf.getTargetSimulator();
             } catch (...) {
-                // Don't throw CircuitConfig exceptions in SimulationConfig and return empty string
-                return val;
+                return SimulatorType::UNSPECIFIED;
             }
         }
         return val;

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -743,7 +743,7 @@ TEST_CASE("SimulationConfig") {
         const auto config = SimulationConfig(contents, basePath);
         const auto network = fs::absolute(basePath / "circuit" / fs::path("circuit_config.json"));
         CHECK(config.getNetwork() == network.lexically_normal());
-        CHECK(config.getTargetSimulator() == SimulatorType::NEURON);  // default
+        CHECK(config.getTargetSimulator() == SimulatorType::UNSPECIFIED);
         CHECK(config.getNodeSetsFile() == "");  // network file is not readable so default empty
         CHECK(config.getNodeSet() == nonstd::nullopt);  // default
         CHECK(config.getRun().stimulusSeed == 0);


### PR DESCRIPTION
if `target_simulator` is not specified in simulation_config, and the circuit_config cannot be loaded; return unspecified