### PR TITLE
Move electrodes_file to per-report LFP blocks

### DIFF
--- a/include/bbp/sonata/config.h
+++ b/include/bbp/sonata/config.h
@@ -320,8 +320,6 @@ class SONATA_API SimulationConfig
         int minisSeed = DEFAULT_minisSeed;
         /// A non-negative integer used for seeding stochastic synapses, default is 0.
         int synapseSeed = DEFAULT_synapseSeed;
-        /// Filename that contains the weights for the LFP calculation.
-        std::string electrodesFile;
     };
     /**
      * Parameters to override simulator output for spike reports
@@ -497,6 +495,8 @@ class SONATA_API SimulationConfig
         std::string fileName;
         /// Allows for suppressing a report so that is not created. Default is true
         bool enabled = true;
+        /// Filename that contains the weights for the LFP calculation (LFP reports only).
+        std::string electrodesFile;
     };
 
     using ReportMap = std::unordered_map<std::string, Report>;

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -801,10 +801,7 @@ PYBIND11_MODULE(_libsonata, m) {
                       DOC_SIMULATIONCONFIG(Run, minisSeed))
         .def_readonly("synapse_seed",
                       &SimulationConfig::Run::synapseSeed,
-                      DOC_SIMULATIONCONFIG(Run, synapseSeed))
-        .def_readonly("electrodes_file",
-                      &SimulationConfig::Run::electrodesFile,
-                      DOC_SIMULATIONCONFIG(Run, electrodesFile));
+                      DOC_SIMULATIONCONFIG(Run, synapseSeed));
 
     py::enum_<SimulationConfig::Run::IntegrationMethod>(run, "IntegrationMethod")
         .value("euler", SimulationConfig::Run::IntegrationMethod::euler)
@@ -968,7 +965,10 @@ PYBIND11_MODULE(_libsonata, m) {
                       DOC_SIMULATIONCONFIG(Report, fileName))
         .def_readonly("enabled",
                       &SimulationConfig::Report::enabled,
-                      DOC_SIMULATIONCONFIG(Report, enabled));
+                      DOC_SIMULATIONCONFIG(Report, enabled))
+        .def_readonly("electrodes_file",
+                      &SimulationConfig::Report::electrodesFile,
+                      DOC_SIMULATIONCONFIG(Report, electrodesFile));
 
     py::enum_<SimulationConfig::Report::Sections>(report, "Sections")
         .value("invalid", SimulationConfig::Report::Sections::invalid)

--- a/python/generated/docstrings.h
+++ b/python/generated/docstrings.h
@@ -1397,6 +1397,10 @@ R"doc(For compartment type, select compartments to report. Default value:
 
 static const char *__doc_bbp_sonata_SimulationConfig_Report_dt = R"doc(Interval between reporting steps in milliseconds)doc";
 
+static const char *__doc_bbp_sonata_SimulationConfig_Report_electrodesFile =
+R"doc(Filename that contains the weights for the LFP calculation (LFP
+reports only).)doc";
+
 static const char *__doc_bbp_sonata_SimulationConfig_Report_enabled =
 R"doc(Allows for suppressing a report so that is not created. Default is
 true)doc";
@@ -1435,8 +1439,6 @@ static const char *__doc_bbp_sonata_SimulationConfig_Run_IntegrationMethod_euler
 static const char *__doc_bbp_sonata_SimulationConfig_Run_IntegrationMethod_invalid = R"doc()doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_Run_dt = R"doc(Integration step duration in milliseconds)doc";
-
-static const char *__doc_bbp_sonata_SimulationConfig_Run_electrodesFile = R"doc(Filename that contains the weights for the LFP calculation.)doc";
 
 static const char *__doc_bbp_sonata_SimulationConfig_Run_integrationMethod =
 R"doc(Selects the NEURON/CoreNEURON integration method. This parameter sets

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -1382,7 +1382,9 @@ class TestSimulationConfig(unittest.TestCase):
                 }
             }
         }
-        self.assertRaises(SonataError, SimulationConfig, json.dumps(contents), './')
+        with self.assertRaises(SonataError) as ctx:
+            SimulationConfig(json.dumps(contents), './')
+        self.assertIn("electrodes_file", str(ctx.exception))
 
     def test_lfp_report_rejects_empty_electrodes_file(self):
         """LFP report with empty electrodes_file should raise an error."""

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -1384,6 +1384,23 @@ class TestSimulationConfig(unittest.TestCase):
         }
         self.assertRaises(SonataError, SimulationConfig, json.dumps(contents), './')
 
+    def test_lfp_report_rejects_empty_electrodes_file(self):
+        """LFP report with empty electrodes_file should raise an error."""
+        contents = {
+            "run": {"tstop": 100, "dt": 0.025, "random_seed": 1},
+            "reports": {
+                "my_lfp": {
+                    "type": "lfp",
+                    "unit": "mV",
+                    "dt": 0.1,
+                    "start_time": 0,
+                    "end_time": 100,
+                    "electrodes_file": ""
+                }
+            }
+        }
+        self.assertRaises(SonataError, SimulationConfig, json.dumps(contents), './')
+
     def test_run_rejects_electrodes_file(self):
         """electrodes_file in run section should raise an error."""
         contents = {

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -435,7 +435,8 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.run.ionchannel_seed, 222)
         self.assertEqual(self.config.run.minis_seed, 333)
         self.assertEqual(self.config.run.synapse_seed, 444)
-        self.assertEqual(self.config.run.electrodes_file,
+        self.assertFalse(hasattr(self.config.run, 'electrodes_file'))
+        self.assertEqual(self.config.report('lfp').electrodes_file,
                          os.path.abspath(os.path.join(PATH, 'config/electrodes/electrode_weights.h5')))
 
         self.assertEqual(self.config.output.output_dir,
@@ -766,7 +767,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(conf.run.ionchannel_seed, 0)
         self.assertEqual(conf.run.minis_seed, 0)
         self.assertEqual(conf.run.synapse_seed, 0)
-        self.assertEqual(conf.run.electrodes_file, "")
+        self.assertFalse(hasattr(conf.run, 'electrodes_file'))
         self.assertEqual(conf.run.spike_threshold, -30.0)
 
     def test_seclamp_without_duration_levels(self):
@@ -1329,3 +1330,65 @@ class TestSimulationConfig(unittest.TestCase):
         with self.assertRaises(SonataError) as e:
             SimulationConfig(contents, "./")
         self.assertEqual(e.exception.args,("Duplicate name 'TTXdup' in 'modifications'",))
+
+    def test_lfp_report_optional_variable_name(self):
+        """LFP report without variable_name should parse without error."""
+        contents = {
+            "run": {"tstop": 100, "dt": 0.025, "random_seed": 1},
+            "reports": {
+                "my_lfp": {
+                    "type": "lfp",
+                    "unit": "mV",
+                    "dt": 0.1,
+                    "start_time": 0,
+                    "end_time": 100,
+                    "electrodes_file": "electrodes/electrode_weights.h5"
+                }
+            }
+        }
+        config = SimulationConfig(json.dumps(contents), './')
+        self.assertEqual(config.report('my_lfp').type, SimulationConfig.Report.Type.lfp)
+        self.assertEqual(config.report('my_lfp').variable_name, '')
+
+    def test_lfp_report_requires_electrodes_file(self):
+        """LFP report without electrodes_file should raise an error."""
+        contents = {
+            "run": {"tstop": 100, "dt": 0.025, "random_seed": 1},
+            "reports": {
+                "my_lfp": {
+                    "type": "lfp",
+                    "unit": "mV",
+                    "dt": 0.1,
+                    "start_time": 0,
+                    "end_time": 100
+                }
+            }
+        }
+        self.assertRaises(SonataError, SimulationConfig, json.dumps(contents), './')
+
+    def test_run_rejects_electrodes_file(self):
+        """electrodes_file in run section should raise an error."""
+        contents = {
+            "run": {"tstop": 100, "dt": 0.025, "random_seed": 1,
+                    "electrodes_file": "some_file.h5"},
+            "reports": {}
+        }
+        self.assertRaises(SonataError, SimulationConfig, json.dumps(contents), './')
+
+    def test_non_lfp_report_rejects_electrodes_file(self):
+        """electrodes_file on non-LFP report should raise an error."""
+        contents = {
+            "run": {"tstop": 100, "dt": 0.025, "random_seed": 1},
+            "reports": {
+                "my_report": {
+                    "type": "compartment",
+                    "variable_name": "v",
+                    "unit": "mV",
+                    "dt": 0.1,
+                    "start_time": 0,
+                    "end_time": 100,
+                    "electrodes_file": "some_file.h5"
+                }
+            }
+        }
+        self.assertRaises(SonataError, SimulationConfig, json.dumps(contents), './')

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -1427,3 +1427,20 @@ class TestSimulationConfig(unittest.TestCase):
             }
         }
         self.assertRaises(SonataError, SimulationConfig, json.dumps(contents), './')
+
+    def test_report_rejects_empty_variable_name(self):
+        """Non-LFP report with empty variable_name should raise an error."""
+        contents = {
+            "run": {"tstop": 100, "dt": 0.025, "random_seed": 1},
+            "reports": {
+                "my_report": {
+                    "type": "compartment",
+                    "variable_name": "",
+                    "unit": "mV",
+                    "dt": 0.1,
+                    "start_time": 0,
+                    "end_time": 100
+                }
+            }
+        }
+        self.assertRaises(SonataError, SimulationConfig, json.dumps(contents), './')

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -1329,7 +1329,7 @@ class TestSimulationConfig(unittest.TestCase):
             SimulationConfig(contents, "./")
         self.assertEqual(e.exception.args,("Duplicate name 'TTXdup' in 'modifications'",))
 
-    def test_lfp_report_optional_variable_name(self):
+    def test_lfp_report_without_variable_name(self):
         """LFP report without variable_name should parse without error."""
         contents = {
             "run": {"tstop": 100, "dt": 0.025, "random_seed": 1},

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -435,7 +435,6 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.run.ionchannel_seed, 222)
         self.assertEqual(self.config.run.minis_seed, 333)
         self.assertEqual(self.config.run.synapse_seed, 444)
-        self.assertFalse(hasattr(self.config.run, 'electrodes_file'))
         self.assertEqual(self.config.report('lfp').electrodes_file,
                          os.path.abspath(os.path.join(PATH, 'config/electrodes/electrode_weights.h5')))
 
@@ -767,7 +766,6 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(conf.run.ionchannel_seed, 0)
         self.assertEqual(conf.run.minis_seed, 0)
         self.assertEqual(conf.run.synapse_seed, 0)
-        self.assertFalse(hasattr(conf.run, 'electrodes_file'))
         self.assertEqual(conf.run.spike_threshold, -30.0)
 
     def test_seclamp_without_duration_levels(self):
@@ -1349,6 +1347,26 @@ class TestSimulationConfig(unittest.TestCase):
         config = SimulationConfig(json.dumps(contents), './')
         self.assertEqual(config.report('my_lfp').type, SimulationConfig.Report.Type.lfp)
         self.assertEqual(config.report('my_lfp').variable_name, '')
+
+    def test_lfp_report_rejects_variable_name(self):
+        """LFP report with variable_name should raise an error."""
+        contents = {
+            "run": {"tstop": 100, "dt": 0.025, "random_seed": 1},
+            "reports": {
+                "my_lfp": {
+                    "type": "lfp",
+                    "variable_name": "v",
+                    "unit": "mV",
+                    "dt": 0.1,
+                    "start_time": 0,
+                    "end_time": 100,
+                    "electrodes_file": "electrodes/electrode_weights.h5"
+                }
+            }
+        }
+        with self.assertRaises(SonataError) as e:
+            SimulationConfig(json.dumps(contents), './')
+        self.assertIn("variable_name", str(e.exception))
 
     def test_lfp_report_requires_electrodes_file(self):
         """LFP report without electrodes_file should raise an error."""

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1359,7 +1359,6 @@ class SimulationConfig::Parser
             parseOptional(valueIt, "file_name", report.fileName, {it.key() + ".h5"});
             parseOptional(valueIt, "enabled", report.enabled, {true});
 
-            // LFP-specific vs non-LFP validation
             if (report.type == Report::Type::lfp) {
                 if (valueIt.find("variable_name") != valueIt.end()) {
                     throw SonataError(

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1388,9 +1388,11 @@ class SimulationConfig::Parser
 
             if (report.type == Report::Type::lfp) {
                 parseMandatory(valueIt, "electrodes_file", debugStr, report.electrodesFile);
-                if (!report.electrodesFile.empty()) {
-                    report.electrodesFile = toAbsolute(_basePath, report.electrodesFile);
+                if (report.electrodesFile.empty()) {
+                    throw SonataError(
+                        fmt::format("'electrodes_file' must not be empty in {}", debugStr));
                 }
+                report.electrodesFile = toAbsolute(_basePath, report.electrodesFile);
             } else {
                 if (valueIt.find("electrodes_file") != valueIt.end()) {
                     throw SonataError(

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1364,18 +1364,13 @@ class SimulationConfig::Parser
                 }
             } else {
                 parseMandatory(valueIt, "variable_name", debugStr, report.variableName);
-            }
-
-            parseOptional(valueIt, "unit", report.unit, {"mV"});
-            parseMandatory(valueIt, "dt", debugStr, report.dt);
-            parseMandatory(valueIt, "start_time", debugStr, report.startTime);
-            parseMandatory(valueIt, "end_time", debugStr, report.endTime);
-            parseOptional(valueIt, "file_name", report.fileName, {it.key() + ".h5"});
-            parseOptional(valueIt, "enabled", report.enabled, {true});
-
-            // variable names can look like:
-            // `v`, or `i_clamp`, or `Foo.bar` but not `..asdf`, or `asdf..` or `asdf.asdf.asdf`
-            if (!report.variableName.empty()) {
+                if (report.variableName.empty()) {
+                    throw SonataError(
+                        fmt::format("'variable_name' must not be empty in {}", debugStr));
+                }
+                // variable names can look like:
+                // `v`, or `i_clamp`, or `Foo.bar` but not `..asdf`, or `asdf..`
+                // or `asdf.asdf.asdf`
                 const char* const varName = R"(\w+(?:\.?\w+)?)";
                 // variable names are separated by `,` with any amount of whitespace separating
                 // them
@@ -1385,6 +1380,13 @@ class SimulationConfig::Parser
                                                   report.variableName));
                 }
             }
+
+            parseOptional(valueIt, "unit", report.unit, {"mV"});
+            parseMandatory(valueIt, "dt", debugStr, report.dt);
+            parseMandatory(valueIt, "start_time", debugStr, report.startTime);
+            parseMandatory(valueIt, "end_time", debugStr, report.endTime);
+            parseOptional(valueIt, "file_name", report.fileName, {it.key() + ".h5"});
+            parseOptional(valueIt, "enabled", report.enabled, {true});
 
             if (report.type == Report::Type::lfp) {
                 parseMandatory(valueIt, "electrodes_file", debugStr, report.electrodesFile);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1250,10 +1250,11 @@ class SimulationConfig::Parser
                       {Run::DEFAULT_ionchannelSeed});
         parseOptional(*runIt, "minis_seed", result.minisSeed, {Run::DEFAULT_minisSeed});
         parseOptional(*runIt, "synapse_seed", result.synapseSeed, {Run::DEFAULT_synapseSeed});
-        parseOptional(*runIt, "electrodes_file", result.electrodesFile, {""});
 
-        if (!result.electrodesFile.empty()) {
-            result.electrodesFile = toAbsolute(_basePath, result.electrodesFile);
+        if (runIt->find("electrodes_file") != runIt->end()) {
+            throw SonataError(
+                "Field 'electrodes_file' is no longer valid in the 'run' section. "
+                "Please specify 'electrodes_file' in each LFP report block instead.");
         }
 
         return result;
@@ -1350,7 +1351,14 @@ class SimulationConfig::Parser
                                       ? Report::Compartments::center
                                       : Report::Compartments::all)});
             parseOptional(valueIt, "scaling", report.scaling, {Report::Scaling::area});
-            parseMandatory(valueIt, "variable_name", debugStr, report.variableName);
+
+            // Variable name: mandatory for non-LFP, optional for LFP
+            if (report.type == Report::Type::lfp) {
+                parseOptional(valueIt, "variable_name", report.variableName, {""});
+            } else {
+                parseMandatory(valueIt, "variable_name", debugStr, report.variableName);
+            }
+
             parseOptional(valueIt, "unit", report.unit, {"mV"});
             parseMandatory(valueIt, "dt", debugStr, report.dt);
             parseMandatory(valueIt, "start_time", debugStr, report.startTime);
@@ -1360,12 +1368,30 @@ class SimulationConfig::Parser
 
             // variable names can look like:
             // `v`, or `i_clamp`, or `Foo.bar` but not `..asdf`, or `asdf..` or `asdf.asdf.asdf`
-            const char* const varName = R"(\w+(?:\.?\w+)?)";
-            // variable names are separated by `,` with any amount of whitespace separating them
-            const std::regex expr(fmt::format(R"({}(?:\s*,\s*{})*)", varName, varName));
-            if (!std::regex_match(report.variableName, expr)) {
-                throw SonataError(fmt::format("Invalid comma separated variable names '{}'",
-                                              report.variableName));
+            if (!report.variableName.empty()) {
+                const char* const varName = R"(\w+(?:\.?\w+)?)";
+                // variable names are separated by `,` with any amount of whitespace separating
+                // them
+                const std::regex expr(fmt::format(R"({}(?:\s*,\s*{})*)", varName, varName));
+                if (!std::regex_match(report.variableName, expr)) {
+                    throw SonataError(fmt::format("Invalid comma separated variable names '{}'",
+                                                  report.variableName));
+                }
+            }
+
+            // Electrodes file: mandatory for LFP reports, rejected for all others
+            if (report.type == Report::Type::lfp) {
+                parseMandatory(valueIt, "electrodes_file", debugStr, report.electrodesFile);
+                if (!report.electrodesFile.empty()) {
+                    report.electrodesFile = toAbsolute(_basePath, report.electrodesFile);
+                }
+            } else {
+                if (valueIt.find("electrodes_file") != valueIt.end()) {
+                    throw SonataError(
+                        fmt::format("Field 'electrodes_file' is not allowed in {}. "
+                                    "It is only valid for LFP reports.",
+                                    debugStr));
+                }
             }
 
             const auto extension = fs::path(report.fileName).extension().string();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1352,7 +1352,14 @@ class SimulationConfig::Parser
                                       : Report::Compartments::all)});
             parseOptional(valueIt, "scaling", report.scaling, {Report::Scaling::area});
 
-            // Variable name: mandatory for non-LFP, not allowed for LFP
+            parseOptional(valueIt, "unit", report.unit, {"mV"});
+            parseMandatory(valueIt, "dt", debugStr, report.dt);
+            parseMandatory(valueIt, "start_time", debugStr, report.startTime);
+            parseMandatory(valueIt, "end_time", debugStr, report.endTime);
+            parseOptional(valueIt, "file_name", report.fileName, {it.key() + ".h5"});
+            parseOptional(valueIt, "enabled", report.enabled, {true});
+
+            // LFP-specific vs non-LFP validation
             if (report.type == Report::Type::lfp) {
                 if (valueIt.find("variable_name") != valueIt.end()) {
                     throw SonataError(
@@ -1362,6 +1369,13 @@ class SimulationConfig::Parser
                                     "report configuration.",
                                     debugStr));
                 }
+
+                parseMandatory(valueIt, "electrodes_file", debugStr, report.electrodesFile);
+                if (report.electrodesFile.empty()) {
+                    throw SonataError(
+                        fmt::format("'electrodes_file' must not be empty in {}", debugStr));
+                }
+                report.electrodesFile = toAbsolute(_basePath, report.electrodesFile);
             } else {
                 parseMandatory(valueIt, "variable_name", debugStr, report.variableName);
                 if (report.variableName.empty()) {
@@ -1379,23 +1393,7 @@ class SimulationConfig::Parser
                     throw SonataError(fmt::format("Invalid comma separated variable names '{}'",
                                                   report.variableName));
                 }
-            }
 
-            parseOptional(valueIt, "unit", report.unit, {"mV"});
-            parseMandatory(valueIt, "dt", debugStr, report.dt);
-            parseMandatory(valueIt, "start_time", debugStr, report.startTime);
-            parseMandatory(valueIt, "end_time", debugStr, report.endTime);
-            parseOptional(valueIt, "file_name", report.fileName, {it.key() + ".h5"});
-            parseOptional(valueIt, "enabled", report.enabled, {true});
-
-            if (report.type == Report::Type::lfp) {
-                parseMandatory(valueIt, "electrodes_file", debugStr, report.electrodesFile);
-                if (report.electrodesFile.empty()) {
-                    throw SonataError(
-                        fmt::format("'electrodes_file' must not be empty in {}", debugStr));
-                }
-                report.electrodesFile = toAbsolute(_basePath, report.electrodesFile);
-            } else {
                 if (valueIt.find("electrodes_file") != valueIt.end()) {
                     throw SonataError(
                         fmt::format("Field 'electrodes_file' is not allowed in {}. "

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1352,9 +1352,16 @@ class SimulationConfig::Parser
                                       : Report::Compartments::all)});
             parseOptional(valueIt, "scaling", report.scaling, {Report::Scaling::area});
 
-            // Variable name: mandatory for non-LFP, optional for LFP
+            // Variable name: mandatory for non-LFP, not allowed for LFP
             if (report.type == Report::Type::lfp) {
-                parseOptional(valueIt, "variable_name", report.variableName, {""});
+                if (valueIt.find("variable_name") != valueIt.end()) {
+                    throw SonataError(
+                        fmt::format("Field 'variable_name' is not allowed in {} (type 'lfp'). "
+                                    "LFP reports always use the membrane current "
+                                    "(i_membrane). Please remove 'variable_name' from the "
+                                    "report configuration.",
+                                    debugStr));
+                }
             } else {
                 parseMandatory(valueIt, "variable_name", debugStr, report.variableName);
             }
@@ -1379,7 +1386,6 @@ class SimulationConfig::Parser
                 }
             }
 
-            // Electrodes file: mandatory for LFP reports, rejected for all others
             if (report.type == Report::Type::lfp) {
                 parseMandatory(valueIt, "electrodes_file", debugStr, report.electrodesFile);
                 if (!report.electrodesFile.empty()) {

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -355,7 +355,6 @@
          "lfp": {
             "cells": "All",
             "type": "lfp",
-            "variable_name": "v",
             "unit": "mV",
             "dt": 0.1,
             "start_time": 0.0,

--- a/tests/data/config/simulation_config.json
+++ b/tests/data/config/simulation_config.json
@@ -29,7 +29,6 @@
          "synapse_seed": 444,
          "integration_method" : "crank_nicolson_ion",
          "forward_skip": 500,
-         "electrodes_file": "$ELECTRODES_DIR/electrode_weights.h5",
          "spike_threshold": -35.5
     },
     "output": {
@@ -360,7 +359,8 @@
             "unit": "mV",
             "dt": 0.1,
             "start_time": 0.0,
-            "end_time": 110000.0
+            "end_time": 110000.0,
+            "electrodes_file": "$ELECTRODES_DIR/electrode_weights.h5"
         },
          "axonal_comp_centers": {
               "cells": "Mosaic",

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -323,7 +323,7 @@ TEST_CASE("SimulationConfig") {
             fs::path("./data/config/simulation_config.json").parent_path());
 
         const auto electrodesPath = fs::absolute(basePath / "electrodes/electrode_weights.h5");
-        CHECK(config.getRun().electrodesFile == (electrodesPath).lexically_normal());
+        CHECK(config.getReport("lfp").electrodesFile == (electrodesPath).lexically_normal());
 
         CHECK_NOTHROW(config.getOutput());
         const auto outputPath = fs::absolute(basePath / "some/path/output");
@@ -752,7 +752,6 @@ TEST_CASE("SimulationConfig") {
         CHECK(config.getRun().ionchannelSeed == 0);
         CHECK(config.getRun().minisSeed == 0);
         CHECK(config.getRun().synapseSeed == 0);
-        CHECK(config.getRun().electrodesFile == "");
         CHECK(config.getRun().spikeThreshold == -30.0);
     }
 


### PR DESCRIPTION
## Summary

Implements the spec change that moves `electrodes_file` from the global `run` section to individual LFP report 
blocks, and makes `variable_name` optional for LFP reports.

Fix: #50 

More discussion in: https://github.com/openbraininstitute/sonata-extension/pull/34

## Changes

- **Report struct**: Added `electrodesFile` field to `SimulationConfig::Report`
- **Run struct**: Removed `electrodesFile` field from `SimulationConfig::Run`
- **Parser**: `parseRun()` now rejects `electrodes_file` with a helpful migration message; `parseReports()` handles per-report parsing for LFP and rejects it for non-LFP types
- **variable_name**: Now optional for LFP reports (LFP always uses i_membrane)
- **Python bindings**: `electrodes_file` moved from `SimulationConfig.Run` to `SimulationConfig.Report`
- **Tests**: Updated existing tests, added new unit tests and property-based tests

## Breaking Changes

- `SimulationConfig.Run.electrodes_file` no longer exists (Python)
- `SimulationConfig::Run::electrodesFile` no longer exists (C++)
- Configs with `electrodes_file` in the `run` section will now throw an error with migration guidance

## References

Spec: sonata-extension branch `katta/per-report-electrodes-file`