### PR TITLE
Make sure absolute SimulationConfig output paths are correctly based at `output_dir`

### DIFF
--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -441,7 +441,7 @@ class TestSimulationConfig(unittest.TestCase):
         self.assertEqual(self.config.output.output_dir,
                          os.path.abspath(os.path.join(PATH, 'config/some/path/output')))
         self.assertEqual(self.config.output.spikes_file,
-                         os.path.abspath(os.path.join(PATH, 'config/out.h5')))
+                         os.path.abspath(os.path.join(PATH, 'config/some/path/output/out.h5')))
         self.assertEqual(self.config.output.log_file, '')
         self.assertEqual(self.config.output.spikes_sort_order,
                          SimulationConfig.Output.SpikesSortOrder.by_id)
@@ -1455,7 +1455,7 @@ class TestSimulationConfig(unittest.TestCase):
         sc = SimulationConfig(json.dumps(contents), '/some/path/')
         self.assertEqual(sc.output.output_dir, "/some/path/output")
         self.assertEqual(sc.output.log_file, "")
-        self.assertEqual(sc.output.spikes_file, "/some/path/out.h5")
+        self.assertEqual(sc.output.spikes_file, "/some/path/output/out.h5")
 
         contents = {
             "run": {"tstop": 100, "dt": 0.025, "random_seed": 1},
@@ -1464,7 +1464,7 @@ class TestSimulationConfig(unittest.TestCase):
         sc = SimulationConfig(json.dumps(contents), '/some/path/')
         self.assertEqual(sc.output.output_dir, "/some/path/output")
         self.assertEqual(sc.output.log_file, "")
-        self.assertEqual(sc.output.spikes_file, "/some/path/out.h5")
+        self.assertEqual(sc.output.spikes_file, "/some/path/output/out.h5")
 
         contents = {
             "run": {"tstop": 100, "dt": 0.025, "random_seed": 1},
@@ -1472,5 +1472,5 @@ class TestSimulationConfig(unittest.TestCase):
         }
         sc = SimulationConfig(json.dumps(contents), '/some/path/')
         self.assertEqual(sc.output.output_dir, "/some/path/output")
-        self.assertEqual(sc.output.log_file, "/some/path/log_file")
-        self.assertEqual(sc.output.spikes_file, "/some/path/out.h5")
+        self.assertEqual(sc.output.log_file, "/some/path/output/log_file")
+        self.assertEqual(sc.output.spikes_file, "/some/path/output/out.h5")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1266,7 +1266,7 @@ class SimulationConfig::Parser
         const auto outputIt = _json.find("output");
         if (outputIt == _json.end()) {
             result.outputDir = toAbsolute(_basePath, result.outputDir);
-            result.spikesFile = toAbsolute(_basePath, result.spikesFile);
+            result.spikesFile = toAbsolute(result.outputDir, result.spikesFile);
             return result;
         }
         parseOptional(*outputIt, "output_dir", result.outputDir, {Output::DEFAULT_outputDir});
@@ -1278,9 +1278,9 @@ class SimulationConfig::Parser
                       {Output::DEFAULT_sortOrder});
 
         result.outputDir = toAbsolute(_basePath, result.outputDir);
-        result.spikesFile = toAbsolute(_basePath, result.spikesFile);
+        result.spikesFile = toAbsolute(result.outputDir, result.spikesFile);
         if (!result.logFile.empty()) {
-            result.logFile = toAbsolute(_basePath, result.logFile);
+            result.logFile = toAbsolute(result.outputDir, result.logFile);
         }
 
         return result;

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -323,12 +323,12 @@ TEST_CASE("SimulationConfig") {
             fs::path("./data/config/simulation_config.json").parent_path());
 
         const auto electrodesPath = fs::absolute(basePath / "electrodes/electrode_weights.h5");
-        CHECK(config.getReport("lfp").electrodesFile == (electrodesPath).lexically_normal());
+        CHECK(config.getReport("lfp").electrodesFile == electrodesPath.lexically_normal());
 
         CHECK_NOTHROW(config.getOutput());
         const auto outputPath = fs::absolute(basePath / "some/path/output").lexically_normal();
         CHECK(config.getOutput().outputDir == outputPath);
-        CHECK(config.getOutput().spikesFile == (basePath / "out.h5").lexically_normal());
+        CHECK(config.getOutput().spikesFile == (outputPath / "out.h5").lexically_normal());
         CHECK(config.getOutput().logFile.empty());
         CHECK(config.getOutput().sortOrder == SimulationConfig::Output::SpikesSortOrder::by_id);
 


### PR DESCRIPTION
* previously, the `log_file` and `spikes_file` were not being output under the `output_dir` as described by the SONATA specification: ```Location where output files should be written, namely spikes and reports.```